### PR TITLE
Append z-index to dropdown menu in LangSelector.js for the purpose of prevent to be hidden by avatar image

### DIFF
--- a/pages/components/LangSelector.js
+++ b/pages/components/LangSelector.js
@@ -46,7 +46,7 @@ const Dropdown = ({ color }) => {
 
   
   <div ref={popoverDropdownRef} className={
-              (dropdownPopoverShow ? "block " : "hidden ") + "origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5"}>
+              (dropdownPopoverShow ? "block " : "hidden ") + "z-10 origin-top-right absolute right-0 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5"}>
     <div className="py-1" role="menu" aria-orientation="vertical" aria-labelledby="options-menu">
     <Link href="#" locale="ja">
       <a href="#" className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 hover:text-gray-900" role="menuitem">日本語</a>


### PR DESCRIPTION
On the environment that has narrow viewport (such as smartphone), dropdown menu of language selector is being hidden by avatar image.
This pull request aims to fix such problem by appending z-index to dropdown menu.

![2021-05-01 17 15 24 yude jp 6178d6bd791b](https://user-images.githubusercontent.com/46831731/116775932-d7fb6c00-aaa0-11eb-8859-c0a3cd3bc9d6.png)
